### PR TITLE
added logic to support mmol units

### DIFF
--- a/nightscout-ps1.sh
+++ b/nightscout-ps1.sh
@@ -27,6 +27,16 @@ nightscout_ps1() {
 		delta="+${delta}"
 	fi
 
+	# If the server is set to use mmol units get the scaled values
+	# and handle the delta calculation needing to support floating points
+	if [ "${displaySettings}" = "mmol" ]; then
+		bgl="${latest_entry_scaled}"
+		# use bc to work out the floating point delta
+		delta="$(bc <<< ${latest_entry_scaled}-${previous_entry_scaled})"
+		# format the delta to 1 d.p. and add the + symbol
+		delta="$(printf '%+0.1f' "${delta}")"
+	fi
+
 	# If the previous reading was more than 6 minutes ago (5 minutes is
 	# normal, plus or minus some time to allow the reading to be uploaded,
 	# then the delta is considered questionable so append an asterisk


### PR DESCRIPTION
In the UK we don't really use mg/dl as blood glucose units and instead we use mmol/L. I have added a block of logic to use the scaled values if the server is using mmol as the units. This also meant changes to how the delta is calculated because mmol/L are not integers.